### PR TITLE
Question: Why multi-stage instead of a base image

### DIFF
--- a/Dockerfile.createcache
+++ b/Dockerfile.createcache
@@ -4,16 +4,10 @@
 
 # docker build -t devtools:latest -f Dockerfile.createcache .
 
-FROM centos:7 as dev_tool_cache 
+FROM centos:7
 
 #enable cache
 RUN sed -i 's/keepcache=0/keepcache=1/g' /etc/yum.conf
 
 #Download Development Tools
 RUN yum --setopt=group_package_types=mandatory,default,optional groupinstall -y "Development Tools"
-
-FROM alpine:3.6 
-
-COPY --from=dev_tool_cache /var/cache/yum/x86_64 /var/cache/yum/x86_64 
-
-RUN ls /var/cache/yum/x86_64/7

--- a/Dockerfile.dev_env
+++ b/Dockerfile.dev_env
@@ -2,12 +2,7 @@
 
 # Usage : time docker build -t devenv:latest -f Dockerfile.dev_env .
 
-# Uncomment next line and COPY line to use "Development Tools" cache
-#FROM devtools:centos7 as dev_tool_cache
-
-FROM centos:7 
-
-#COPY --from=dev_tool_cache /var/cache/yum/x86_64 /var/cache/yum/x86_64
+FROM devtools
 
 RUN echo "Setting up dev environment"
 


### PR DESCRIPTION
This PR is for the sake of discussion only; not for merging.

Question: Why use multi-stage builds here instead of just using a base image?

My thoughts on this already:
- Multi-stage builds can help save space in the image size. However assuming that we will have centos:7 in our registry anyway, then I don't think, in this case, we actually save any space that matters practically. With the base image approach, the devtools image is larger, but the part a multi-stage build eliminates (centos:7) will always need to be downloaded/stored anyway to build the dev_env or production image. Deduplication of layers in Docker and in the registry means we don't get any savings here.
- Given the above, in this example, multi-stage builds just add complexity.

Are there more complex scenarios that you come across that make it better to use multi-stage builds than a base image? Or infeasible to use a single base image?

In attempting to answer my own question, here are some ideas I have:
- In this example, cache comes only from one source. If we have multiple sources (e.g. yum cache, npm/rubygems/whatever cache, dependency compilation, etc.), then using a base image would require that updating earlier image layers implies invalidating all subsequent layers. Using multi-stage builds allows you to import from multiple sources, and invalidate only the cache images that actually changed.
- The cache image doesn't necessarily have to be built using the same base image as the dev_env image. This makes less sense with apt but more sense with npm/rubygems, where node packages or ruby gems can be imported into any number of images with different bases.

In your experience, are there other reasons why the multi-stage build approach helps?